### PR TITLE
chore : 주소 API URL 및 KEY env 내 저장 및 콘솔 로그 삭제

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+REACT_APP_ADDRESS_API_KEY="devU01TX0FVVEgyMDIyMDEyODIzMjIyNjExMjE5NjE="
+REACT_APP_ADDRESS_URL="https://www.juso.go.kr/addrlink/addrLinkApi.do"

--- a/src/components/CarePlace/CarePlace.tsx
+++ b/src/components/CarePlace/CarePlace.tsx
@@ -48,19 +48,19 @@ function CareType({ setDisabled }: { setDisabled: React.Dispatch<React.SetStateA
   const checkVailidity = () => {
     const isFilledDiagnose = diagnoseDetail !== "" || isDiagnosed ? 1 : 0;
 
-    console.log(targetGender, careGender, longtermLvl, isFilledDiagnose);
+    // console.log(targetGender, careGender, longtermLvl, isFilledDiagnose);
 
     if (selectPlace === 2) {
-      console.log("validate");
+      // console.log("validate");
       setDisabled(false);
     } else if (wantSurvice === 2) {
-      console.log("validate");
+      // console.log("validate");
       setDisabled(false);
     } else if (targetGender * careGender * longtermLvl * isFilledDiagnose) {
-      console.log("validate");
+      // console.log("validate");
       setDisabled(false);
     } else {
-      console.log("not yet");
+      // console.log("not yet");
       setDisabled(true);
     }
   };

--- a/src/components/RegisterAddress/RegisterAddress.tsx
+++ b/src/components/RegisterAddress/RegisterAddress.tsx
@@ -62,6 +62,8 @@ function RegisterAddress({ setRoute, setDisabled }: RegisterAddressProps) {
   const [covidTest, setCovidTest] = useState<string | null>(null);
   const dispatch = useApplicationDispatch();
 
+  // const apiKey: string = process.env.REACT_APP_ADDRESS_API_KEY as string;
+
   useEffect(() => {
     if (filterdAddr?.roadAddress && detailAddress && covidTest) {
       const tmpObj: Address = filterdAddr;
@@ -84,19 +86,18 @@ function RegisterAddress({ setRoute, setDisabled }: RegisterAddressProps) {
       sidoName: value.siNm,
       sigunguName: value.sggNm,
     };
-
     setFilterdAddr(filterdObj);
     setModalState(false);
   };
 
   async function getAddress(SearchValue: string) {
     try {
-      const response = await axios.get<RespAddr>("https://www.juso.go.kr/addrlink/addrLinkApi.do", {
+      const response = await axios.get<RespAddr>(process.env.REACT_APP_ADDRESS_URL as string, {
         params: {
           currentPage: 1,
           countPerPage: 10,
           keyword: SearchValue,
-          confmKey: "devU01TX0FVVEgyMDIyMDEyODIzMjIyNjExMjE5NjE=",
+          confmKey: process.env.REACT_APP_ADDRESS_API_KEY,
           resultType: "json",
         },
       });


### PR DESCRIPTION
## 개요 🪧

- 제목과 동일 합니다. 

## 작업 내용 📄

- env 파일을 생성하여 주소 API에 필요한 url 와 api 키를 밖으로 뺐습니다. 
- 카드가 넘어갈때마다 해당 카드의 콘솔이 찍혀서 cardplace의 콘솔을 주석처리하였습니다.

## 스크린샷 📸
